### PR TITLE
Make ExportProvider contract more explicit

### DIFF
--- a/export/src/main/java/io/gdcc/spi/export/DatasetExportQuery.java
+++ b/export/src/main/java/io/gdcc/spi/export/DatasetExportQuery.java
@@ -9,6 +9,7 @@ import java.util.Set;
 /**
  * Defines <em>what</em> dataset metadata to retrieve and at what level of detail
  * for dataset-oriented export operations.
+ *
  * <p>
  * This is a pure data-shape specification: it answers which aspects of a dataset
  * should be included in an export, and optionally how file metadata nested within
@@ -16,13 +17,13 @@ import java.util.Set;
  * datasets to operate on (that is a selection concern at a higher level), nor
  * <em>how much</em> data to retrieve per call — pagination is a separate,
  * orthogonal concern expressed via a {@code PageRequest} at the method level.
- * <p>
- * File metadata shaping is optional: if no {@link FileExportQuery} is provided,
- * methods that include file metadata will apply their own defaults. Methods that
- * do not return file metadata will ignore any nested {@link FileExportQuery}.
+ *
+ * <p>File metadata shaping is optional: if no {@link FileExportQuery} is provided at build time,
+ * {@link FileExportQuery#none} is included, resulting in file metadata addition being skipped.
+ *
  * <p>
  * Instances are immutable and must be constructed via {@link #builder()}.
- * Use {@link #defaults()} for the standard query with no special filtering.
+ * Use {@link #defaults()} for the standard query with no special filtering and skipping files.
  *
  * @see FileExportQuery
  * @see DatasetMetadataPredicates
@@ -49,6 +50,17 @@ public final class DatasetExportQuery {
      */
     public static Builder builder() {
         return new Builder();
+    }
+    
+    /**
+     * Creates a new {@link Builder} pre-populated with the state of the given query.
+     * This is useful for deriving a modified copy of the query without altering the original.
+     *
+     * @param source the {@link DatasetExportQuery} instance to copy from
+     * @return a new {@link Builder} instance pre-configured with the same predicates and file query as the provided {@code source}
+     */
+    public static Builder builder(DatasetExportQuery source) {
+        return new Builder().from(source);
     }
     
     /**
@@ -126,12 +138,16 @@ public final class DatasetExportQuery {
         
         /**
          * Builds an immutable {@link DatasetExportQuery}.
+         * If no {@link FileExportQuery} was set, the default {@link FileExportQuery#none()} will be used.
          *
          * @return a new, validated {@link DatasetExportQuery}
-         * @throws IllegalArgumentException if the predicate combination is invalid,
-         *         e.g. due to conflicting predicates
+         * @throws IllegalArgumentException if the predicate combination is invalid, e.g., due to conflicting predicates
          */
         public DatasetExportQuery build() {
+            // If no fileQuery was set, the default is to skip file metadata from being included
+            if (this.fileQuery == null) {
+                this.fileQuery = FileExportQuery.none();
+            }
             return new DatasetExportQuery(this);
         }
         
@@ -157,21 +173,19 @@ public final class DatasetExportQuery {
      *
      * @return an unmodifiable set of {@link DatasetMetadataPredicates}; never {@code null}
      */
-    public Set<DatasetMetadataPredicates> getDatasetPredicates() {
+    public Set<DatasetMetadataPredicates> predicates() {
         return datasetPredicates;
     }
     
     /**
-     * Returns the optional {@link FileExportQuery} that controls how file metadata
-     * nested within this dataset export should be shaped.
-     * <p>
-     * An empty {@link Optional} means no explicit file query was specified; methods
-     * that include file metadata will apply their own defaults in that case.
+     * Returns the {@link FileExportQuery} that controls how file metadata nested within this dataset export should be shaped.
      *
-     * @return an {@link Optional} containing the file export query, or empty if not set
+     * <p>The default value is {@link FileExportQuery#none()}, resulting in no file metadata being queried.
+     *
+     * @return an {@link Optional} containing the file export query
      */
-    public Optional<FileExportQuery> getFileQuery() {
-        return Optional.ofNullable(fileQuery);
+    public FileExportQuery fileQuery() {
+        return fileQuery;
     }
     
     @Override

--- a/export/src/main/java/io/gdcc/spi/export/ExportDataProvider.java
+++ b/export/src/main/java/io/gdcc/spi/export/ExportDataProvider.java
@@ -4,11 +4,14 @@ package io.gdcc.spi.export;
 import io.gdcc.spi.meta.plugin.CoreProvider;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.json.stream.JsonCollectors;
 import org.w3c.dom.Document;
 
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.stream.Stream;
+
+import static io.gdcc.spi.export.FileMetadataPredicates.INCLUDE_TABULAR_DATA_VARIABLES;
 
 /**
  * Provides dataset metadata that can be used by an {@link Exporter} to create
@@ -26,9 +29,12 @@ import java.util.stream.Stream;
  * <h3>Context Handling</h3>
  * Implementations should respect context options where applicable.
  * Not all methods support all context options - see individual method documentation for details.
+ * <p>
  * All methods require a non-null {@link DatasetExportQuery} or {@link FileExportQuery}.
  * Passing null will result in a {@link NullPointerException}.
- * Callers should use {@link DatasetExportQuery#defaults()} respectivelly {@link FileExportQuery#defaults()} instead of passing null.
+ * <p>
+ * Callers should use {@link DatasetExportQuery#defaults()} respectivelly {@link FileExportQuery#all()}
+ * or {@link FileExportQuery#all()} or build their own instead of passing null.
  *
  * @see Exporter
  * @see DatasetExportQuery
@@ -41,9 +47,11 @@ public interface ExportDataProvider extends CoreProvider {
     /**
      * Returns complete dataset metadata in Dataverse's standard JSON format.
      * <p>
-     * This format includes comprehensive dataset-level metadata along with basic
-     * metadata for each file in the dataset. It is the same JSON format used in
-     * the Dataverse API and available as a metadata export option in the UI.
+     * This format prioritizes comprehensive dataset-level metadata.
+     * It is the same JSON format used in the Dataverse API and available as a metadata export option in the UI.
+     * <p>
+     * Optionally, it may include metadata for each file in the dataset, depending on the {@link FileExportQuery}
+     * contained in the given {@link DatasetExportQuery} {@code query}.
      *
      * @param query specification for data retrieval
      * @return dataset metadata in Dataverse JSON format
@@ -53,24 +61,26 @@ public interface ExportDataProvider extends CoreProvider {
      * @apiNote While no formal JSON schema exists for this format, it is well-documented
      *          in the Dataverse guides. Along with OAI_ORE, this is one of only two export
      *          formats that provide complete dataset and file metadata.
-     * @implNote Implementations must respect the {@code datasetMetadataOnly} flag.
-     *           When true, file-level metadata should be excluded to optimize performance
-     *           for datasets with large numbers of files. Other context options
-     *           (publicFilesOnly, offset, length) do not apply and should be ignored.
+     * @implNote Implementations must respect the embedded file export query describing what file metadata to embed.
      */
     JsonObject getDatasetJson(DatasetExportQuery query);
     
     /**
-     * Returns complete dataset metadata using default options.
+     * Returns complete dataset metadata, including basic file metadata (but no details like tabular data metadata).
+     * Note: for datasets with large numbers of files, this may be an issue with memory consumption!
      *
      * @return dataset metadata in Dataverse JSON format
      * @throws ExportException if metadata retrieval fails
      * @since 1.0.0
      * @deprecated since 2.1.0, for removal in 3.0.0. Use {@link #getDatasetJson(DatasetExportQuery)} instead.
+     * @apiNote For backward compatibility, this method includes basic file metadata,
+     *          while the newer methods will not include file metadata by default!
      */
     @Deprecated(since = "2.1.0", forRemoval = true)
     default JsonObject getDatasetJson() {
-        return getDatasetJson(DatasetExportQuery.defaults());
+        return getDatasetJson(DatasetExportQuery.builder()
+            .fileQuery(FileExportQuery.all())
+            .build());
     }
     
     /**
@@ -79,6 +89,9 @@ public interface ExportDataProvider extends CoreProvider {
      * OAI-ORE (Open Archives Initiative Object Reuse and Exchange) provides a structured way to describe
      * aggregations of web resources. This format is used in Dataverse's archival bag export mechanism
      * and available via UI and API.
+     * <p>
+     * Optionally, it may include metadata for each file in the dataset, depending on the {@link FileExportQuery}
+     * contained in the given {@link DatasetExportQuery} {@code query}.
      *
      * @param query specification for data retrieval
      * @return dataset metadata in OAI-ORE format
@@ -88,35 +101,38 @@ public interface ExportDataProvider extends CoreProvider {
      * @apiNote Along with the standard JSON format, this is one of only two export
      *          formats that provide complete dataset-level metadata along with basic
      *          file metadata for each file in the dataset.
-     * @implNote Implementations must respect the {@code datasetMetadataOnly} flag.
-     *           Other context options do not apply and should be ignored.
+     * @implNote Implementations must respect the embedded file export query describing what file metadata to embed.
      */
     JsonObject getDatasetORE(DatasetExportQuery query);
     
     /**
-     * Returns dataset metadata in OAI-ORE format using default options.
+     * Returns dataset metadata in OAI-ORE format, including basic file metadata (but no details like tabular data metadata).
+     * Note: for datasets with large numbers of files, this may be an issue with memory consumption!
      *
      * @return dataset metadata in OAI-ORE format
      * @throws ExportException if metadata retrieval fails
      * @since 1.0.0
      * @deprecated since 2.1.0, for removal in 3.0.0. Use {@link #getDatasetORE(DatasetExportQuery)} instead.
+     * @apiNote For backward compatibility, this method includes basic file metadata,
+     *          while the newer methods will not include file metadata by default!
      */
     @Deprecated(since = "2.1.0", forRemoval = true)
     default JsonObject getDatasetORE() {
-        return getDatasetORE(DatasetExportQuery.defaults());
+        return getDatasetORE(DatasetExportQuery.builder()
+            .fileQuery(FileExportQuery.all())
+            .build());
     }
     
     /**
      * Returns detailed metadata for files in the dataset.
      * <p>
-     * For tabular files that have been successfully ingested, this may include
-     * DDI-centric metadata extracted during the ingest process. This detailed
-     * metadata is not available through other methods in this interface.
-     * </p><p>
-     * The query may specify filters to skip certain files or how much metadata details should be included.
+     * If {@link FileExportQuery} has {@link FileMetadataPredicates#INCLUDE_TABULAR_DATA_VARIABLES} set,
+     * for tabular files that have been successfully ingested, this may include DDI-centric metadata
+     * extracted during the ingest process. This detailed metadata is not available through other methods in this interface.
+     * <p>
+     * The query may specify filters to skip certain files or how many metadata details should be included.
      * The resulting stream will contain a limited number of elements only, specified by a {@code PageRequest},
      * avoiding huge memory allocations in the provider.
-     * </p>
      *
      * @param query specification for file data retrieval
      * @param request the page request containing pagination information such as page offset and page size
@@ -133,15 +149,15 @@ public interface ExportDataProvider extends CoreProvider {
     /**
      * Returns detailed metadata for files in the dataset.
      * <p>
-     * For tabular files that have been successfully ingested, this may include
-     * DDI-centric metadata extracted during the ingest process. This detailed
-     * metadata is not available through other methods in this interface.
-     * </p><p>
-     * The query may specify filters to skip certain files or how much metadata details should be included.
+     * If {@link FileExportQuery} has {@link FileMetadataPredicates#INCLUDE_TABULAR_DATA_VARIABLES} set,
+     * for tabular files that have been successfully ingested, this may include DDI-centric metadata
+     * extracted during the ingest process. This detailed metadata is not available through other methods in this interface.
+     * <p>
+     * The query may specify filters to skip certain files or how many metadata details should be included.
      * The resulting stream will contain all matching files for consumption.
+     * <p>
      * In cases with large metadata quantities use {@link #getDatasetFileDetails(FileExportQuery,PageRequest)}
      * for a stream containing a limited number of elements only, avoiding huge memory allocations in the provider.
-     * </p>
      *
      * @param query specification for file data retrieval
      * @return JSON array with one entry per dataset file (both tabular and non-tabular)
@@ -155,12 +171,12 @@ public interface ExportDataProvider extends CoreProvider {
     Stream<JsonObject> getDatasetFileDetails(FileExportQuery query);
     
     /**
-     * Returns detailed metadata for all files using default options.
+     * Returns all available metadata for all files, including tabular data metadata, if available.
      * <p>
      * Note that this method will serialize all file metadata into one large JSON array.
      * This can be memory-intensive for large datasets and should be used judiciously.
      * There have been reports of unexportable large datasets in production installations.
-     * Using {@link #getDatasetFileDetails(FileExportQuery)} instead is advised.
+     * Using {@link #getDatasetFileDetails(FileExportQuery)} (or its paged variant) instead is advised.
      * </p>
      *
      * @return JSON array with one JSON object entry per dataset file
@@ -170,7 +186,12 @@ public interface ExportDataProvider extends CoreProvider {
      *             or {@link #getDatasetFileDetails(FileExportQuery, PageRequest)}instead.
      */
     @Deprecated(since = "2.1.0", forRemoval = true)
-    JsonArray getDatasetFileDetails();
+    default JsonArray getDatasetFileDetails() {
+        return this.getDatasetFileDetails(FileExportQuery.builder(FileExportQuery.all())
+                                                         .addFilePredicate(INCLUDE_TABULAR_DATA_VARIABLES)
+                                                         .build())
+            .collect(JsonCollectors.toJsonArray());
+    }
     
     /**
      * Returns dataset metadata conforming to the schema.org standard.

--- a/export/src/main/java/io/gdcc/spi/export/FileExportQuery.java
+++ b/export/src/main/java/io/gdcc/spi/export/FileExportQuery.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static io.gdcc.spi.export.FileMetadataPredicates.*;
 
@@ -21,8 +22,9 @@ import static io.gdcc.spi.export.FileMetadataPredicates.*;
  * or composed inside a {@code DatasetExportQuery} to specify how file metadata
  * should be shaped within a dataset export.
  * <p>
- * Instances are immutable and must be constructed via {@link #builder()}.
- * Use {@link #defaults()} for the standard all-files query with no special filtering.
+ * Instances are immutable and must be constructed via {@link #builder()} or cloned using {@link #builder(FileExportQuery)}.
+ * Use {@link #all()} for the standard "all files" query with no special filtering.
+ * Use {@link #none()} for the standard "no files" query.
  *
  * @see FileMetadataPredicates
  */
@@ -31,9 +33,13 @@ public final class FileExportQuery {
     private final Set<FileMetadataPredicates> filePredicates;
     
     /**
-     * Default query with no special options.
+     * Query: "include all files without filtering any nor including special details"
      */
-    private static final FileExportQuery DEFAULT = builder().addFilePredicate(ALL_FILES).build();
+    private static final FileExportQuery ALL = builder().addFilePredicate(ALL_FILES).build();
+    /**
+     * Query: "skip all files"
+     */
+    private static final FileExportQuery NONE = builder().addFilePredicate(SKIP_FILES).build();
     
     private FileExportQuery(Builder builder) {
         this.filePredicates = builder.filePredicates;
@@ -47,10 +53,29 @@ public final class FileExportQuery {
     }
     
     /**
-     * Returns a default query, which includes all files without filtering or detail restrictions.
+     * Creates a new {@code Builder} instance initialized with the properties of the given {@code FileExportQuery}.
+     *
+     * @param source the {@code FileExportQuery} instance from which to copy properties
+     * @return a new {@code Builder} instance with properties copied from the provided query
      */
-    public static FileExportQuery defaults() {
-        return DEFAULT;
+    public static Builder builder(FileExportQuery source) {
+        return new Builder().from(source);
+    }
+    
+    /**
+     * Get a simple query: "include all files without filtering any nor including special details"
+     * @return {@link ALL}
+     */
+    public static FileExportQuery all() {
+        return ALL;
+    }
+    
+    /**
+     * Get a simple query: "skip all files"
+     * @return {@link NONE}
+     */
+    public static FileExportQuery none() {
+        return NONE;
     }
     
     /**
@@ -104,10 +129,35 @@ public final class FileExportQuery {
         /**
          * Builds an immutable {@link FileExportQuery}.
          *
+         * <p>As per design, the query may not be lacking a description of which files to include and optionally what
+         * metadata about the selected files. If no, no selective or conflicting predicates have been set,
+         * an exception is thrown.</p>
+         *
          * @return validated context
          * @throws IllegalArgumentException if validation fails
          */
         public FileExportQuery build() {
+            if (this.filePredicates.isEmpty()) {
+                throw new IllegalArgumentException("At least one file metadata predicate must be given for a valid query.");
+            }
+            
+            if (this.filePredicates.stream()
+                .filter(p -> !FileMetadataPredicates.relatesToFileMetadata(p))
+                .findFirst()
+                .isEmpty()) {
+                throw new IllegalArgumentException("At least one file metadata predicate must be about selection of files");
+            }
+            
+            Set<FileMetadataPredicates> conflicts = FileMetadataPredicates.checkConflicts(this.filePredicates);
+            if (!conflicts.isEmpty()) {
+                throw new IllegalArgumentException(
+                    "Conflicting predicates detected: " +
+                    conflicts.stream()
+                        .map(String::valueOf)
+                        .collect(Collectors.joining(", "))
+                );
+            }
+            
             return new FileExportQuery(this);
         }
         
@@ -131,8 +181,17 @@ public final class FileExportQuery {
      *
      * @return an unmodifiable set of {@link FileMetadataPredicates}; never {@code null}
      */
-    public Set<FileMetadataPredicates> getFilePredicates() {
+    public Set<FileMetadataPredicates> predicates() {
         return Collections.unmodifiableSet(filePredicates);
+    }
+    
+    /**
+     * Determine if this query was built requiring a certain {@link FileMetadataPredicates}.
+     * @param predicate to check for
+     * @return true if required, false otherwise
+     */
+    public boolean requires(FileMetadataPredicates predicate) {
+        return filePredicates.contains(predicate);
     }
     
     @Override

--- a/export/src/main/java/io/gdcc/spi/export/FileMetadataPredicates.java
+++ b/export/src/main/java/io/gdcc/spi/export/FileMetadataPredicates.java
@@ -42,17 +42,35 @@ public enum FileMetadataPredicates {
     INCLUDE_TABULAR_DATA_VARIABLES()
     ;
     
-    final Set<FileMetadataPredicates> conflicts;
+    /**
+     * When adding new predicates to the enum, make sure to add any entry which is about *metadata*
+     * of files and not the *selection* of files to this set. It is used to ensure any {@link FileExportQuery}
+     * has at least one *selection* predicate present.
+     */
+    private static final Set<FileMetadataPredicates> fileMetadataRelated = Set.of(INCLUDE_TABULAR_DATA_VARIABLES);
     
-    FileMetadataPredicates(FileMetadataPredicates... predicates) {
-       this.conflicts = Set.of(predicates);
+    /**
+     * Determines if the given {@code FileMetadataPredicates} relates to file metadata rather than file selection.
+     *
+     * @param predicate the {@code FileMetadataPredicates} to check
+     * @return {@code true} if the provided predicate is contained in the set of file metadata-related predicates,
+     *         {@code false} otherwise
+     */
+    public static boolean relatesToFileMetadata(FileMetadataPredicates predicate) {
+        return fileMetadataRelated.contains(predicate);
+    }
+    
+    final Set<FileMetadataPredicates> conflictingPredicates;
+    
+    FileMetadataPredicates(FileMetadataPredicates... conflictingPredicates) {
+       this.conflictingPredicates = Set.of(conflictingPredicates);
     }
     
     public boolean conflictsWith(FileMetadataPredicates p) {
         if (p == null) {
             return false;
         }
-        return conflicts.contains(p);
+        return conflictingPredicates.contains(p);
     }
     
     /**

--- a/export/src/test/java/io/gdcc/spi/export/DatasetExportQueryTest.java
+++ b/export/src/test/java/io/gdcc/spi/export/DatasetExportQueryTest.java
@@ -1,0 +1,23 @@
+package io.gdcc.spi.export;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DatasetExportQueryTest {
+    
+    /**
+     * Tests the builder method with an empty builder.
+     * Verifies that the default fileQuery is set to "none" when no explicit fileQuery is provided.
+     */
+    @Test
+    void testBuilderWithDefaults() {
+        DatasetExportQuery result = DatasetExportQuery.builder().build();
+        
+        assertNotNull(result);
+        assertTrue(result.predicates().isEmpty());
+        assertEquals(FileExportQuery.none(), result.fileQuery());
+    }
+}

--- a/export/src/test/java/io/gdcc/spi/export/FileExportQueryTest.java
+++ b/export/src/test/java/io/gdcc/spi/export/FileExportQueryTest.java
@@ -1,0 +1,104 @@
+package io.gdcc.spi.export;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static io.gdcc.spi.export.FileMetadataPredicates.ALL_FILES;
+import static io.gdcc.spi.export.FileMetadataPredicates.INCLUDE_TABULAR_DATA_VARIABLES;
+import static io.gdcc.spi.export.FileMetadataPredicates.SKIP_FILES;
+
+class FileExportQueryTest {
+    
+    @Test
+    void testBuilderWithSinglePredicate() {
+        FileExportQuery query = FileExportQuery.builder()
+            .addFilePredicate(ALL_FILES)
+            .build();
+        
+        Assertions.assertNotNull(query);
+        Assertions.assertEquals(Set.of(ALL_FILES), query.predicates());
+    }
+    
+    @Test
+    void testBuilderWithMultiplePredicates() {
+        FileExportQuery query = FileExportQuery.builder()
+            .filePredicates(ALL_FILES, INCLUDE_TABULAR_DATA_VARIABLES)
+            .build();
+        
+        Assertions.assertNotNull(query);
+        Assertions.assertEquals(Set.of(ALL_FILES, INCLUDE_TABULAR_DATA_VARIABLES), query.predicates());
+    }
+    
+    @Test
+    void testBuilderFromExistingQuery() {
+        FileExportQuery baseQuery = FileExportQuery.builder()
+            .addFilePredicate(ALL_FILES)
+            .build();
+        
+        FileExportQuery newQuery = FileExportQuery.builder(baseQuery)
+            .addFilePredicate(INCLUDE_TABULAR_DATA_VARIABLES)
+            .build();
+        
+        Assertions.assertNotNull(newQuery);
+        Assertions.assertEquals(Set.of(ALL_FILES, INCLUDE_TABULAR_DATA_VARIABLES), newQuery.predicates());
+    }
+    
+    @Test
+    void testBuilderThrowsExceptionForEmptyPredicates() {
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () ->
+            FileExportQuery.builder().build()
+        );
+        
+        Assertions.assertEquals("At least one file metadata predicate must be given for a valid query.", exception.getMessage());
+    }
+    
+    @Test
+    void testBuilderThrowsExceptionForConflictingPredicates() {
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () ->
+            FileExportQuery.builder()
+                .filePredicates(ALL_FILES, SKIP_FILES)
+                .build()
+        );
+        
+        Assertions.assertTrue(exception.getMessage().contains("Conflicting predicates detected"));
+    }
+    
+    @Test
+    void testBuilderThrowsExceptionWhenNoFileSelectionPredicatePresent() {
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () ->
+            FileExportQuery.builder()
+                .filePredicates(INCLUDE_TABULAR_DATA_VARIABLES)
+                .build()
+        );
+        
+        Assertions.assertTrue(exception.getMessage().contains("At least one file metadata predicate must be about selection of files"));
+    }
+    
+    @Test
+    void testAllStaticMethodReturnsPredefinedQuery() {
+        FileExportQuery query = FileExportQuery.all();
+        
+        Assertions.assertNotNull(query);
+        Assertions.assertEquals(Set.of(ALL_FILES), query.predicates());
+    }
+    
+    @Test
+    void testNoneStaticMethodReturnsPredefinedQuery() {
+        FileExportQuery query = FileExportQuery.none();
+        
+        Assertions.assertNotNull(query);
+        Assertions.assertEquals(Set.of(SKIP_FILES), query.predicates());
+    }
+    
+    @Test
+    void testRequiresMethod() {
+        FileExportQuery query = FileExportQuery.builder()
+            .addFilePredicate(ALL_FILES)
+            .build();
+        
+        Assertions.assertTrue(query.requires(ALL_FILES));
+        Assertions.assertFalse(query.requires(SKIP_FILES));
+    }
+}


### PR DESCRIPTION
After careful discussion with @landreev, we decided to tighten the definition of the query contracts and provide correct backwards compatibility for deprecated methods.